### PR TITLE
Created a no digest option for use in top-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,8 @@ $ ./mimic <path_to_fasta_file>
 |seed                   |    S      | Set seed of the random number generator. Default = 1									 |
 |prepend                |    P      | Prepend the original fasta file to the output											 |
 |help              		|    h      | produce help message      															 |
+|replaceI          		|    I      | Count I as L for homolgy check														 |
+|empiric           		|    e      | Infer amino acid frequency from fasta for mutations									 |
+|no-digest         		|    N      | Do not digest the sequence before scrambling     										 |
 
 

--- a/src/Peptides.cpp
+++ b/src/Peptides.cpp
@@ -330,7 +330,7 @@ bool Peptides::parseOptions(int argc, char **argv){
                      TRUE_IF_SET);
     cmd.defineOption("N",
         "no-digest",
-        "Do not digest the sequence at lysines before scrambling",
+        "Do not digest the sequence before scrambling",
         "",
         TRUE_IF_SET);
 

--- a/src/Peptides.cpp
+++ b/src/Peptides.cpp
@@ -114,7 +114,7 @@ void Peptides::cleaveProtein(string seq, unsigned int& pepNo) {
   if (noDigest_) {
       if (protLen > 0) {
           addPeptide(seq.substr(0, protLen), pepNo++);
-          connectorStrings_.push_back(">");
+		  //connectorStrings_.push_back("");
       }
       return;
   }

--- a/src/Peptides.cpp
+++ b/src/Peptides.cpp
@@ -111,6 +111,13 @@ void Peptides::cleaveProtein(string seq, unsigned int& pepNo) {
   if (protLen > 0 && seq[protLen-1]=='*') {
     --protLen;
   }
+  if (noDigest_) {
+      if (protLen > 0) {
+          addPeptide(seq.substr(0, protLen), pepNo++);
+          connectorStrings_.push_back(">");
+      }
+      return;
+  }
   for (; pos<protLen; pos++) {
     if (pos == 0 || seq[pos] == 'K' || seq[pos] == 'R' || pos==protLen-1) {
       // store peptide without C-terminal 'K/R'
@@ -321,6 +328,11 @@ bool Peptides::parseOptions(int argc, char **argv){
                      "Instead of assuming the AA frequency infer it from the given fasta file",
                      "",
                      TRUE_IF_SET);
+    cmd.defineOption("N",
+        "no-digest",
+        "Do not digest the sequence at lysines before scrambling",
+        "",
+        TRUE_IF_SET);
 
   cmd.parseArgs(argc, argv);
 
@@ -348,6 +360,9 @@ bool Peptides::parseOptions(int argc, char **argv){
   }
   if (cmd.optionSet("e")) {
       inferAAFrequency_ = true;
+  }
+  if (cmd.optionSet("N")) {
+      noDigest_ = true;
   }
 
   if (!cmd.arguments.empty()) {

--- a/src/Peptides.h
+++ b/src/Peptides.h
@@ -72,6 +72,7 @@ class Peptides
     bool inferAAFrequency_;
     AbsAminoAcidDist absBackground_;
     bool isVerbose_ = false;
+    bool noDigest_ = false;
 };
 
 #endif /*PEPTIDES_H_*/


### PR DESCRIPTION
Proteins heavy in K near termini generate entrapment proteins that look very similar to the target proteins. 

This PR adds a new command line parameter to forgo the digestion, enabling mimic databases to be used for top-down. 